### PR TITLE
Protect update_stack and fix rounding to 0 items with "per-time-size" setting

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -105,6 +105,10 @@ end
 -- Helpers
 
 local function update_stack(mtype, multiplier, stack, previous_value, recipe, speed, additive)
+	if not game.item_prototypes[stack.name] then
+		return nil
+	end
+
 	if mtype == "additional-paste-settings-per-stack-size" then
 		if additive and previous_value ~= nil then
 			return previous_value + game.item_prototypes[stack.name].stack_size * multiplier
@@ -145,9 +149,9 @@ local function update_stack(mtype, multiplier, stack, previous_value, recipe, sp
 			end
 		end
 		if additive and previous_value ~= nil then
-			return previous_value + amount * multiplier * speed / recipe.energy
+			return math.ceil(previous_value + amount * multiplier * speed / recipe.energy)
 		else
-			return amount * multiplier * speed / recipe.energy
+			return math.ceil(amount * multiplier * speed / recipe.energy)
 		end
 	else
 		error "error"
@@ -336,7 +340,9 @@ local function on_vanilla_paste(event)
 		end
 		local i = 1
 		for k, v in pairs(result) do
-			if i > event.destination.request_slot_count then
+			if not v or not v.count then
+				-- Nothing to do here.
+			elseif i > event.destination.request_slot_count then
 				game.players[evt.gamer].print('Missing space in chest to paste requests')
 			else
 				event.destination.set_request_slot(v, i)


### PR DESCRIPTION
- Protect update_stack against non-items (specifically fluids); and
- Fixed update_stack "per-time-size" to round to whole number

When the `recipe.energy` was high enough, it could make the result from `update_stack` < 1.0. This would have the effect of adding the item to the logistics but with no count (a count of 0, effectively). The main point of this change is to address that.

The other change in `update_stack` ensures that the stack is an `item_prototype`. I had a paste crash when it tried pasting a fluid. This might be a result of my own personal change that adds a setting which allows the user to decide on the behavior of pasting to a buffer chest (a00cd38), but I thought it a good guard regardless for the mainline.
