### PR TITLE
Fix crash with inverted buffer chest pasting

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -373,10 +373,12 @@ local function on_vanilla_paste(event)
 			end
 		end
 		if invertPaste and recipe then
-			if result[recipe.name] ~= nil then
-				result[recipe.name].count = update_stack(mtype, multiplier, result[recipe.name], result[recipe.name].count, recipe, speed, additive)
-			else
-				result[recipe.name] = { name = recipe.name, count = update_stack(mtype, multiplier, {name = recipe.name}, recipe, speed, additive) }
+			for k, product in pairs(recipe.products) do
+				if result[product.name] ~= nil then
+					result[product.name].count = update_stack(mtype, multiplier, result[product.name], result[product.name].count, recipe, speed, additive)
+				else
+					result[product.name] = { name = product.name, count = update_stack(mtype, multiplier, {name = product.name}, recipe, speed, additive) }
+				end
 			end
 		end
 		local i = 1


### PR DESCRIPTION
Fixes https://mods.factorio.com/mod/additional-paste-settings/discussion/5fc6a5714158dd5b057e8227

The previous code assumed that a recipe has only one product which is the same as the recipe name. That isn't true for mods with multiple ways of producing products. My test case was Py Petroleum Handling's `transport-belt-2` belt recipe.